### PR TITLE
Fix Auto Center on Player not being centered if MiniMap Zoom was different from MainMap Zoom

### DIFF
--- a/Plugin/UI/Components/MapView.cs
+++ b/Plugin/UI/Components/MapView.cs
@@ -344,8 +344,8 @@ namespace DynamicMaps.UI.Components
 
         public void IncrementalZoomInto(float zoomDelta, Vector2 rectPoint, float zoomTweenTime)
         {
-            var zoomNew = Mathf.Clamp(ZoomCurrent + zoomDelta, ZoomMin, ZoomMax);
-            var actualDelta = zoomNew - ZoomCurrent;
+            var zoomNew = Mathf.Clamp(ZoomMain + zoomDelta, ZoomMin, ZoomMax);
+            var actualDelta = zoomNew - ZoomMain;
             var rotatedPoint = MathUtils.GetRotatedVector2(rectPoint, CoordinateRotation);
 
             // have to shift first, so that the tween is started in the shift first

--- a/Plugin/UI/Components/MapView.cs
+++ b/Plugin/UI/Components/MapView.cs
@@ -400,6 +400,13 @@ namespace DynamicMaps.UI.Components
             ShiftMap((-rotatedCoord - currentCenter) * ZoomCurrent, tweenTime, isMini);
         }
 
+        public void ShiftMapToPlayer(Vector2 coord, float tweenTime, bool isMini)
+        {
+            var rotatedCoord = MathUtils.GetRotatedVector2(coord, CoordinateRotation);
+            var currentCenter = RectTransform.anchoredPosition / ZoomMain;
+            ShiftMap((-rotatedCoord - currentCenter) * ZoomMain, tweenTime, isMini);
+        }
+
         public void ScaledShiftMap(Vector2 shiftIncrements, float incrementScale, bool isMini)
         {
             var smallestDimension = Mathf.Min(CurrentMapDef.Bounds.Max.x - CurrentMapDef.Bounds.Min.x,

--- a/Plugin/UI/ModdedMapScreen.cs
+++ b/Plugin/UI/ModdedMapScreen.cs
@@ -698,9 +698,11 @@ namespace DynamicMaps.UI
             
             if (zoomAmount != 0f)
             {
-                var currentCenter = _mapView.RectTransform.anchoredPosition / _mapView.ZoomMain;
+                var player = GameUtils.GetMainPlayer();
+                var mapPosition = MathUtils.ConvertToMapPosition(((IPlayer)player).Position);
                 zoomAmount = _mapView.ZoomMain * zoomAmount * (_zoomMapHotkeySpeed * Time.deltaTime);
-                _mapView.IncrementalZoomInto(zoomAmount, currentCenter, 0f);
+
+                _mapView.IncrementalZoomInto(zoomAmount, mapPosition, 0.0f);
                 
                 return;
             }

--- a/Plugin/UI/ModdedMapScreen.cs
+++ b/Plugin/UI/ModdedMapScreen.cs
@@ -584,7 +584,7 @@ namespace DynamicMaps.UI
                 }
 
                 // shift map to player position, Vector3 to Vector2 discards z
-                _mapView.ShiftMapToCoordinate(mapPosition, 0, false);
+                _mapView.ShiftMapToPlayer(mapPosition, 0, false);
             }
         }
 


### PR DESCRIPTION
Tested: 
- Auto Center On Player + Auto Select Layer
- Auto Center On Player + Auto Select Layer + Reset Zoom
