### PR TITLE
Zoom bug fix

### DIFF
--- a/Plugin/UI/ModdedMapScreen.cs
+++ b/Plugin/UI/ModdedMapScreen.cs
@@ -966,7 +966,7 @@ namespace DynamicMaps.UI
             // Reset size and position when loading map and in raid
             if (GameUtils.IsInRaid())
             {
-                Plugin.Log.LogInfo($"MapScreen: Resetting Map Size");
+                // Plugin.Log.LogInfo($"MapScreen: Resetting Map Size");
                 AdjustSizeAndPosition();
             }
 

--- a/Plugin/UI/ModdedMapScreen.cs
+++ b/Plugin/UI/ModdedMapScreen.cs
@@ -306,6 +306,7 @@ namespace DynamicMaps.UI
         {
             if (!_initialized)
             {
+                //Plugin.Log.LogInfo("Map was not initialized, is resetting size and position");
                 AdjustSizeAndPosition();
                 _initialized = true;
             }
@@ -698,11 +699,9 @@ namespace DynamicMaps.UI
             
             if (zoomAmount != 0f)
             {
-                var player = GameUtils.GetMainPlayer();
-                var mapPosition = MathUtils.ConvertToMapPosition(((IPlayer)player).Position);
+                var currentCenter = _mapView.RectTransform.anchoredPosition / _mapView.ZoomMain;
                 zoomAmount = _mapView.ZoomMain * zoomAmount * (_zoomMapHotkeySpeed * Time.deltaTime);
-
-                _mapView.IncrementalZoomInto(zoomAmount, mapPosition, 0.0f);
+                _mapView.IncrementalZoomInto(zoomAmount, currentCenter, 0f);
                 
                 return;
             }
@@ -963,6 +962,13 @@ namespace DynamicMaps.UI
             }
 
             Plugin.Log.LogInfo($"MapScreen: Loading map {mapDef.DisplayName}");
+
+            // Reset size and position when loading map and in raid
+            if (GameUtils.IsInRaid())
+            {
+                Plugin.Log.LogInfo($"MapScreen: Resetting Map Size");
+                AdjustSizeAndPosition();
+            }
 
             _mapView.LoadMap(mapDef);
 


### PR DESCRIPTION
Revert OnZoomMain() - This is unnecessary and also breaks shifting map out of raid
Fix ChangeMap() - This resets the scroll rect and map rect before loading the map def, prevents the scroll rect from staying gigantic if you run the same map again. Tested running same map again (was guaranteed to cause it before) and also running a different map